### PR TITLE
Make state updates for displacement and damage explicit

### DIFF
--- a/code/gradient_damage/gradient_damage.py
+++ b/code/gradient_damage/gradient_damage.py
@@ -477,7 +477,7 @@ solver_alpha_snes.setVariableBounds(alpha_lb.x.petsc_vec, alpha_ub.x.petsc_vec)
 # enhanced with a line search procedure to compute how far along the direction
 # $d^k$ we should move.
 #
-# Let us now test the solution of the damage problem at the computed displacement
+# Let us now test the solution of the damage problem at a fixed displacement
 # +
 u.x.array[:] = x_u.x.array
 solver_alpha_snes.solve(None, x_alpha.x.petsc_vec)

--- a/code/gradient_damage/gradient_damage.py
+++ b/code/gradient_damage/gradient_damage.py
@@ -540,10 +540,8 @@ def alternate_minimization(x_u, x_alpha, atol=1e-8, max_iterations=100, monitor=
         u.x.array[:] = x_u.x.array
         solver_alpha_snes.solve(None, x_alpha.x.petsc_vec)
 
-        # Fix damage
+        # Fix damage, check error and update
         alpha.x.array[:] = x_alpha.x.array
-
-        # Check error and update
         error_L2 = np.sqrt(comm.allreduce(fem.assemble_scalar(L2_error), op=MPI.SUM))
 
         monitor(x_u, x_alpha, iteration, error_L2)

--- a/code/gradient_damage/gradient_damage.py
+++ b/code/gradient_damage/gradient_damage.py
@@ -382,9 +382,11 @@ solver_u_snes.getKSP().getPC().setType("lu")
 # +
 load = 1.0
 u_D.value = load
-u.x.array[:] = 0.0
-solver_u_snes.solve(None, u.x.petsc_vec)
-plot_damage_state(u, alpha, load=load)
+
+u_h = fem.Function(V_u)
+alpha_h = fem.Function(V_alpha)
+solver_u_snes.solve(None, u_h.x.petsc_vec)
+plot_damage_state(u_h, alpha_h, load=load)
 
 # + [markdown]
 # ### Damage problem with bound-constraint
@@ -476,14 +478,14 @@ solver_alpha_snes.setVariableBounds(alpha_lb.x.petsc_vec, alpha_ub.x.petsc_vec)
 #
 # Let us now test the solution of the damage problem
 # +
-solver_alpha_snes.solve(None, alpha.x.petsc_vec)
-plot_damage_state(u, alpha, load=load)
+solver_alpha_snes.solve(None, alpha_h.x.petsc_vec)
+plot_damage_state(u_h, alpha_h, load=load)
 
 # + [markdown]
 # Before continuing we reset the displacement and damage to zero.
 # +
-alpha.x.array[:] = 0.0
-u.x.array[:] = 0.0
+alpha_h.x.array[:] = 0.0
+u_h.x.array[:] = 0.0
 
 # + [markdown]
 # ### The static problem: solution with the alternate minimization algorithm
@@ -510,20 +512,21 @@ def alternate_minimization(u, alpha, atol=1e-8, max_iterations=100, monitor=simp
 
     for iteration in range(max_iterations):
         # Solve for displacement
-        solver_u_snes.solve(None, u.x.petsc_vec)
+        solver_u_snes.solve(None, u_h.x.petsc_vec)
         # This forward scatter is necessary when `solver_u_snes` is of type `ksponly`.
-        u.x.scatter_forward()
+        u_h.x.scatter_forward()
 
         # Solve for damage
-        solver_alpha_snes.solve(None, alpha.x.petsc_vec)
+        solver_alpha_snes.solve(None, alpha_h.x.petsc_vec)
+        alpha_h.x.scatter_forward()
 
         # Check error and update
-        L2_error = ufl.inner(alpha - alpha_old, alpha - alpha_old) * dx
+        L2_error = ufl.inner(alpha_h - alpha_old, alpha_h - alpha_old) * dx
         error_L2 = np.sqrt(comm.allreduce(fem.assemble_scalar(fem.form(L2_error)), op=MPI.SUM))
-        alpha_old.x.array[:] = alpha.x.array
+        alpha_old.x.array[:] = alpha_h.x.array
 
         if monitor is not None:
-            monitor(u, alpha, iteration, error_L2)
+            monitor(u_h, alpha_h, iteration, error_L2)
 
         if error_L2 <= atol:
             return (error_L2, iteration)
@@ -547,11 +550,14 @@ for i_t, t in enumerate(loads):
     energies[i_t, 0] = t
 
     # Update the lower bound to ensure irreversibility of damage field.
-    alpha_lb.x.array[:] = alpha.x.array
+    alpha_lb.x.array[:] = alpha_h.x.array
 
     print(f"-- Solving for t = {t:3.2f} --")
-    alternate_minimization(u, alpha)
-    plot_damage_state(u, alpha)
+    alternate_minimization(u_h, alpha_h)
+    
+    u.x.array[:] = u_h.x.array 
+    alpha.x.array[:] = alpha_h.x.array 
+    plot_damage_state(u_h, alpha_h)
 
     # Calculate the energies
     energies[i_t, 1] = comm.allreduce(

--- a/code/gradient_damage/gradient_damage.py
+++ b/code/gradient_damage/gradient_damage.py
@@ -386,8 +386,10 @@ u_D.value = load
 u_h = fem.Function(V_u)
 alpha_h = fem.Function(V_alpha)
 solver_u_snes.solve(None, u_h.x.petsc_vec)
-u.x.array[:] = u_h.x.array
-plot_damage_state(u, alpha, load=load)
+plot_damage_state(u_h, alpha_h, load=load)
+
+# Explicitly update the state of the damage problem
+alpha.x.array[:] = alpha_h.x.array
 
 # + [markdown]
 # ### Damage problem with bound-constraint
@@ -482,14 +484,14 @@ solver_alpha_snes.setVariableBounds(alpha_lb.x.petsc_vec, alpha_ub.x.petsc_vec)
 solver_alpha_snes.solve(None, alpha_h.x.petsc_vec)
 alpha.x.array[:] = alpha_h.x.array
 plot_damage_state(u, alpha, load=load)
+del u_h
+del alpha_h
 
 # + [markdown]
 # Before continuing we reset the displacement and damage to zero.
 # +
 alpha.x.array[:] = 0.0
 u.x.array[:] = 0.0
-u_h.x.array[:] = 0.0
-alpha_h.x.array[:] = 0.0
 
 # + [markdown]
 # ### The static problem: solution with the alternate minimization algorithm
@@ -510,15 +512,38 @@ def simple_monitor(u, alpha, iteration, error_L2):
     print(f"Iteration: {iteration}, Error: {error_L2:3.4e}")
 
 
-alpha_old = fem.Function(alpha.function_space)
-L2_error = fem.form(ufl.inner(alpha - alpha_old, alpha - alpha_old) * dx)
+alpha_prev = fem.Function(alpha.function_space)
+L2_error = fem.form(ufl.inner(alpha - alpha_prev, alpha - alpha_prev) * dx)
 
-def alternate_minimization(u_h, alpha_h, atol=1e-8, max_iterations=100, monitor=simple_monitor): 
-    alpha_old.x.array[:] = alpha.x.array
+
+def alternate_minimization(u, alpha, atol=1e-8, max_iterations=100, monitor=simple_monitor):
+    """
+    Perform alternate minimisation on displacement and damage problems.
+
+    Args:
+        u: Initial guess for displacement
+        alpha: Initial guess for damage
+        atol: termination criterion based absolute tolerance as L^2 distance
+            between current and previous damage iteration.
+        max_iterations: termination criterion on alternate minimisation
+            iterations
+        monitor: monitor function
+
+    Returns:
+        The displacement, damage, the alternate minimisation error and the
+        number of iterations.
+    """
+    u_h = fem.Function(V_u)
+    alpha_h = fem.Function(V_alpha)
+
+    u_h.x.array[:] = u.x.array
+    alpha_h.x.array[:] = u.x.array
+
     for iteration in range(max_iterations):
+        alpha_prev.x.array[:] = alpha.x.array
+
         # Solve for displacement
         solver_u_snes.solve(None, u_h.x.petsc_vec)
-        # This forward scatter is necessary when `solver_u_snes` is of type `ksponly`.
         u_h.x.scatter_forward()
         u.x.array[:] = u_h.x.array
 
@@ -529,13 +554,12 @@ def alternate_minimization(u_h, alpha_h, atol=1e-8, max_iterations=100, monitor=
 
         # Check error and update
         error_L2 = np.sqrt(comm.allreduce(fem.assemble_scalar(L2_error), op=MPI.SUM))
-        alpha_old.x.array[:] = alpha.x.array
 
         if monitor is not None:
-            monitor(u, alpha, iteration, error_L2)
+            monitor(u_h, alpha_h, iteration, error_L2)
 
         if error_L2 <= atol:
-            return (error_L2, iteration)
+            return (u_h, alpha_h, error_L2, iteration)
 
     raise RuntimeError(
         f"Could not converge after {max_iterations} iterations, error {error_L2:3.4e}"
@@ -557,17 +581,14 @@ for i_t, t in enumerate(loads):
 
     # Update the lower bound to ensure irreversibility of damage field.
     alpha_lb.x.array[:] = alpha.x.array
-   
-    # Store the old value of the damage 
-    alpha_old.x.array[:] = alpha.x.array
 
     print(f"-- Solving for t = {t:3.2f} --")
-    alternate_minimization(u_h, alpha_h)
-    u.x.array[:] = u_h.x.array
-    alpha.x.array[:] = alpha_h.x.array
-    
+    u_h, alpha_h, error_L2, num_iterations = alternate_minimization(u, alpha)
+
     plot_damage_state(u, alpha)
 
+    u.x.array[:] = u_h.x.array
+    alpha.x.array[:] = alpha_h.x.array
     # Calculate the energies
     energies[i_t, 1] = comm.allreduce(
         dolfinx.fem.assemble_scalar(dolfinx.fem.form(elastic_energy)),

--- a/code/utils/petsc_problems.py
+++ b/code/utils/petsc_problems.py
@@ -32,6 +32,10 @@ class SNESProblem:
 
     def J(self, snes, x, J, P):
         """Assemble Jacobian matrix."""
+        x.ghostUpdate(addv=PETSc.InsertMode.INSERT, mode=PETSc.ScatterMode.FORWARD)
+        x.copy(self.u.x.petsc_vec)
+        self.u.x.petsc_vec.ghostUpdate(addv=PETSc.InsertMode.INSERT, mode=PETSc.ScatterMode.FORWARD)
+        
         J.zeroEntries()
         fem.petsc.assemble_matrix(J, self.a, bcs=self.bcs)
         J.assemble()

--- a/code/utils/petsc_problems.py
+++ b/code/utils/petsc_problems.py
@@ -35,7 +35,7 @@ class SNESProblem:
         x.ghostUpdate(addv=PETSc.InsertMode.INSERT, mode=PETSc.ScatterMode.FORWARD)
         x.copy(self.u.x.petsc_vec)
         self.u.x.petsc_vec.ghostUpdate(addv=PETSc.InsertMode.INSERT, mode=PETSc.ScatterMode.FORWARD)
-        
+
         J.zeroEntries()
         fem.petsc.assemble_matrix(J, self.a, bcs=self.bcs)
         J.assemble()


### PR DESCRIPTION
This PR decouples the state of the residual and Jacobian from the current solution vector. This fixes the issues with SNES line search and removes implicit updates in the alternate minimisation algorithm.